### PR TITLE
Removed Sonar comments

### DIFF
--- a/tests/tests_results.py
+++ b/tests/tests_results.py
@@ -9,7 +9,7 @@ from rest_framework.test import APITestCase
 
 
 class TestResultTestCase(APITestCase):
-    def setUp(self):  # NOPMD
+    def setUp(self):
         self.test_run = mommy.make('test_runs.TestRun')
         self.task = mommy.make('tasks.Task')
         self.result_to_delete = mommy.make('results.TestResult')

--- a/tests/tests_tasks.py
+++ b/tests/tests_tasks.py
@@ -11,7 +11,8 @@ from tasks.models import TaskStatus
 
 
 class TestResultTestCase(APITestCase):
-    def setUp(self): # NOPMD
+    # NOPMD
+    def setUp(self):
         self.test_run = mommy.make('test_runs.TestRun')
         self.task_to_delete = mommy.make('tasks.Task')
         self.result = mommy.make('results.TestResult')

--- a/tests/tests_tasks.py
+++ b/tests/tests_tasks.py
@@ -11,7 +11,6 @@ from tasks.models import TaskStatus
 
 
 class TestResultTestCase(APITestCase):
-    # NOPMD
     def setUp(self):
         self.test_run = mommy.make('test_runs.TestRun')
         self.task_to_delete = mommy.make('tasks.Task')

--- a/tests/tests_testruns.py
+++ b/tests/tests_testruns.py
@@ -11,7 +11,7 @@ from test_runs.models import TestRunStatus
 
 
 class TestResultTestCase(APITestCase):
-    def setUp(self): # NOPMD
+    def setUp(self):
         self.testrun_to_delete = mommy.make('test_runs.TestRun')
         self.task_to_delete = mommy.make('tasks.Task')
         self.result = mommy.make('results.TestResult')


### PR DESCRIPTION
It seems that Sonar doesn't respect in-code comments to silence false positive errors in Check Style rules so we remove them altogether.