### PR TITLE
Better resiliency when running tests

### DIFF
--- a/apps/sparrow/settings/base.py
+++ b/apps/sparrow/settings/base.py
@@ -221,7 +221,7 @@ SPARROW_TEST_RUNNER = {
     ],
     'api_server': get_env_var('SPARROW_API_URI'),
     'phantomas_path': get_env_var('SPARROW_RUNNER_PHANTOMAS'),
-    'use_virtual_display': 'DISPLAY' not in os.environ,
+    'use_virtual_display': ('DISPLAY' not in os.environ) or (os.environ.get('SPARROW_FORCE_VIRTUAL_DISPLAY','0') != '0'),
 }
 
 CRHOMEDRIVER_PATH = get_env_var('SPARROW_RUNNER_CHROMEDRIVER')

--- a/common/utils.py
+++ b/common/utils.py
@@ -28,3 +28,20 @@ def camel2snake(text):
         pos += 1
 
     return "".join(result)
+
+
+def collect_results(func, count, error_limit=3):
+    results = []
+    consecutive_errors = 0
+    while len(results) < count:
+        try:
+            result = func()
+            if not result:
+                raise ValueError('Result evaluates to false: {}'.format(result))
+            consecutive_errors = 0
+            results.append(result)
+        except:
+            consecutive_errors += 1
+            if consecutive_errors >= error_limit:
+                raise
+    return results


### PR DESCRIPTION
Per recent discussions single test runs fail often and they crash the entire test suite. Let's be more resilient and re-run tests.

Single test needs to fail 3 times in a row to crash the entire suite.

/cc @jcellary @harnash 