### PR TITLE
Get rid of chromedriver zombie processes

### DIFF
--- a/apps/testrunner/tasks/selenium_get.py
+++ b/apps/testrunner/tasks/selenium_get.py
@@ -19,6 +19,15 @@ from django.conf import settings
 logger = get_task_logger(__name__)
 
 
+class quitting(object):
+    def __init__(self, thing):
+        self.thing = thing
+    def __enter__(self):
+        return self.thing
+    def __exit__(self, *exc_info):
+        self.thing.quit()
+
+
 class SeleniumGet(celery_app.Task):
     @staticmethod
     def get_driver():
@@ -95,21 +104,14 @@ class SeleniumGet(celery_app.Task):
 
     def run_test(self, test):
         logger.info('Running selenium test: ' + test['test_name'])
-        driver = None
         try:
-            driver = self.get_driver()
+            with quitting(self.get_driver()) as driver:
+                timer = SeleniumTimer(driver)
+                timer.start()
 
-            timer = SeleniumTimer(driver)
-            timer.start()
+                test_func = getattr(selenium_tests, test['test_func'])
+                test_func(driver, timer, test['params'])
 
-            test_func = getattr(selenium_tests, test['test_func'])
-            test_func(driver, timer, test['params'])
-
-            return timer.get_result()
+                return timer.get_result()
         except:
             logger.error('Exception caught while running selenium test: ' + test['test_name'], exc_info=True)
-        finally:
-            if driver is not None:
-                driver.quit()
-
-

--- a/apps/testrunner/tasks/selenium_get.py
+++ b/apps/testrunner/tasks/selenium_get.py
@@ -95,17 +95,21 @@ class SeleniumGet(celery_app.Task):
 
     def run_test(self, test):
         logger.info('Running selenium test: ' + test['test_name'])
+        driver = None
         try:
-            with closing(self.get_driver()) as driver:
+            driver = self.get_driver()
 
-                timer = SeleniumTimer(driver)
-                timer.start()
+            timer = SeleniumTimer(driver)
+            timer.start()
 
-                test_func = getattr(selenium_tests, test['test_func'])
-                test_func(driver, timer, test['params'])
+            test_func = getattr(selenium_tests, test['test_func'])
+            test_func(driver, timer, test['params'])
 
-                return timer.get_result()
+            return timer.get_result()
         except:
             logger.error('Exception caught while running selenium test: ' + test['test_name'], exc_info=True)
+        finally:
+            if driver is not None:
+                driver.quit()
 
 


### PR DESCRIPTION
Chromedriver processes are not killed after the single selenium test run finishes. This should fix the problem.

Unfortunately I didn't find similar solution to closing() that would allow me to call .quit() Anyone has other idea than creating quitting()?

/cc @harnash @jcellary 