### PR TITLE
Remove old releases from target host after deployment

### DIFF
--- a/apps/testrunner/tasks/deploy.py
+++ b/apps/testrunner/tasks/deploy.py
@@ -2,22 +2,32 @@
 from __future__ import unicode_literals
 from contextlib import closing
 
+from celery.utils.log import get_task_logger
+
 from testrunner import app as celery_app
 from testrunner.ssh import SSHConnection
 
+logger = get_task_logger(__name__)
+
 
 class Deploy(celery_app.Task):
+    PACKAGE_DIR = '/data/deploytools/packages/wikia/'
+    PACKAGE_EXT = '.tar.gz'
+    DEPLOY_DIR = '/usr/wikia/source/deploytools/'
+
     def run(self, deploy_host, app, env, repos):
         with closing(SSHConnection(deploy_host)) as connection:
             self.run_prep(connection, app, env, repos)
             self.run_push(connection, app, env)
+        with closing(SSHConnection(env)) as connection:
+            self.clean_up_old_releases(env, connection)
 
     @classmethod
     def run_prep(cls, connection, app, env, repos):
         repo_spec = ' '.join([
-            '-r {repo_name}@{repo_commit}'.format(repo_name=repo_name, repo_commit=repo_commit)
-            for repo_name, repo_commit in repos.items()
-        ])
+                                 '-r {repo_name}@{repo_commit}'.format(repo_name=repo_name, repo_commit=repo_commit)
+                                 for repo_name, repo_commit in repos.items()
+                                 ])
 
         cmd = 'dt --boring -y prep -a {app} -e {env} {repo_spec}'.format(
             app=app,
@@ -36,13 +46,45 @@ class Deploy(celery_app.Task):
 
         cls.run_remote_command(connection, cmd)
 
+    @classmethod
+    def clean_up_old_releases(cls, hostname, connection):
+        current_release = int(cls.get_remote_output(connectoin, 'readlink {}current'.format(cls.DEPLOY_DIR)))
+        current_release_str = str(current_release)
+        logger.debug('{}: current_release = {}'.format(hostname, current_release))
+
+        deployed_releases = cls.get_remote_output(connection, 'ls {}'.format(cls.DEPLOY_DIR)).split()
+        logger.debug('{}: deployed_releases = {}'.format(hostname, deployed_releases))
+
+        for f in deployed_releases:
+            if f == 'current' or f == current_release_str or f.startswith('.'):
+                continue
+            logger.debug('{}: removing deployed release {}'.format(hostname, f))
+            cls.run_remote_command(connection, 'rm -rf {}{}'.format(cls.DEPLOY_DIR, f))
+
+        packages = cls.get_remote_output(connection, 'ls {}'.format(cls.PACKAGE_DIR)).split()
+        logger.debug('{}: packages = {}'.format(hostname, packages))
+
+        for f in packages:
+            if f.startswith('.') or not f.endswith(cls.PACKAGE_EXT):
+                continue
+            p = f[:len(f) - len(cls.PACKAGE_EXT)]
+            app, sep, release = p.rpartition('-')
+            release = int(release)
+            logger.debug('{}: package file {}: release = {}'.format(hostname, f, release))
+            if release == current_release:
+                continue
+            logger.debug('{}: removing package {}'.format(hostname, f))
+            cls.run_remote_command(connection, 'rm {}{}'.format(cls.PACKAGE_DIR, f))
+
+    @classmethod
+    def get_remote_output(cls, connection, cmd):
+        return cls.run_remote_command(connection, cmd)[0].strip()
+
     @staticmethod
     def run_remote_command(connection, cmd):
         status, stdout, stderr = connection.execute(cmd)
 
         if status != 0:
-            raise RuntimeError('Remote command execution failed.',
-                               cmd,
-                               status,
-                               stdout.getvalue(),
-                               stderr.getvalue())
+            raise RuntimeError('Remote command execution failed.', cmd, status, stdout, stderr)
+
+        return (stdout, stderr)

--- a/apps/testrunner/tasks/deploy.py
+++ b/apps/testrunner/tasks/deploy.py
@@ -25,9 +25,9 @@ class Deploy(celery_app.Task):
     @classmethod
     def run_prep(cls, connection, app, env, repos):
         repo_spec = ' '.join([
-                                 '-r {repo_name}@{repo_commit}'.format(repo_name=repo_name, repo_commit=repo_commit)
-                                 for repo_name, repo_commit in repos.items()
-                                 ])
+            '-r {repo_name}@{repo_commit}'.format(repo_name=repo_name, repo_commit=repo_commit)
+            for repo_name, repo_commit in repos.items()
+        ])
 
         cmd = 'dt --boring -y prep -a {app} -e {env} {repo_spec}'.format(
             app=app,
@@ -48,7 +48,7 @@ class Deploy(celery_app.Task):
 
     @classmethod
     def clean_up_old_releases(cls, hostname, connection):
-        current_release = int(cls.get_remote_output(connectoin, 'readlink {}current'.format(cls.DEPLOY_DIR)))
+        current_release = int(cls.get_remote_output(connection, 'readlink {}current'.format(cls.DEPLOY_DIR)))
         current_release_str = str(current_release)
         logger.debug('{}: current_release = {}'.format(hostname, current_release))
 

--- a/tests/mocks/ssh.py
+++ b/tests/mocks/ssh.py
@@ -5,10 +5,19 @@ from __future__ import unicode_literals
 class SSHConnectionMock(object):
     """ Simple mock class to simulate SSHConnection"""
     def __init__(self, *args, **kwargs):
-        pass
+        self.ret_stdout = ''
+        self.ret_stderr = ''
 
     def close(self):
         pass
 
     def execute(self, *args, **kwargs):
-        return (0, None, None)
+        return (0, self.ret_stdout, self.ret_stdout)
+
+def SSHConnectionMockBuilder(stdout='', stderr=''):
+    def wrapper(*args,**kwargs):
+        mock = SSHConnectionMock(*args, **kwargs)
+        mock.ret_stdout = stdout
+        mock.ret_stderr = stderr
+        return mock
+    return wrapper

--- a/tests/tests_tasks.py
+++ b/tests/tests_tasks.py
@@ -14,7 +14,7 @@ from rest_framework.test import APITestCase
 from metrics.values import Stats
 
 from tasks.models import TaskStatus
-from tests.mocks.ssh import SSHConnectionMock
+from tests.mocks.ssh import SSHConnectionMock, SSHConnectionMockBuilder
 from tests.mocks.requests import post_response
 from tests.mocks.phantomas import PhantomasMock
 from tests.mocks.chrome import ChromeMock
@@ -66,7 +66,7 @@ class TestResultTestCase(APITestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK, msg='Read failed: {0}'.format(response.data))
 
-    @mock.patch('testrunner.tasks.deploy.SSHConnection', SSHConnectionMock)
+    @mock.patch('testrunner.tasks.deploy.SSHConnection', SSHConnectionMockBuilder('1'))
     @mock.patch('testrunner.tasks.phantomas_get.phantomas.Phantomas', PhantomasMock)
     @mock.patch('testrunner.tasks.selenium_get.webdriver.Chrome', ChromeMock.create)
     @mock.patch('selenium.webdriver.support.wait.WebDriverWait', mock.MagicMock())


### PR DESCRIPTION
This should solve our problems with disk space on target machine as all the releases except the current one will be automatically removed after deployment is finished.

/cc @harnash @jcellary 