### PR TITLE
Run everything in one celery task

### DIFF
--- a/apps/testrunner/test_suites/simple.py
+++ b/apps/testrunner/test_suites/simple.py
@@ -26,7 +26,7 @@ class SimpleTestSuite(object):
         self.TARGET_ENV = test_runner_config['target_hosts'][0]['hostname']
 
     def run(self, **kwargs):
-        if not 'retries' in kwargs:
+        if kwargs.get('retries') is None:
             kwargs['retries'] = self.DEFAULT_RETRIES_COUNT
 
         logger.info('Started execution of task #{} (x{})'.format(kwargs['task_uri'], kwargs['retries']))

--- a/tests/tests_tasks.py
+++ b/tests/tests_tasks.py
@@ -20,6 +20,9 @@ from tests.mocks.phantomas import PhantomasMock
 from tests.mocks.chrome import ChromeMock
 
 
+def noop(*args, **kwargs):
+    pass
+
 @override_settings(CELERY_ALWAYS_EAGER=True)
 class TestResultTestCase(APITestCase):
     def setUp(self):
@@ -70,6 +73,7 @@ class TestResultTestCase(APITestCase):
     @mock.patch('testrunner.tasks.phantomas_get.phantomas.Phantomas', PhantomasMock)
     @mock.patch('testrunner.tasks.selenium_get.webdriver.Chrome', ChromeMock.create)
     @mock.patch('selenium.webdriver.support.wait.WebDriverWait', mock.MagicMock())
+    @mock.patch('testrunner.test_suites.simple.SimpleTestSuiteTask.on_success', noop)
     @responses.activate
     @post_response
     def test_run_task(self, post_callback):


### PR DESCRIPTION
This should solve our problems with growing memory consumptions on the server since no test/task result data will be registered in celery and in redis.

/cc @harnash @jcellary 