### PR TITLE
Report time taken to complete HTTP request as request time

### DIFF
--- a/apps/testrunner/metric_generators.py
+++ b/apps/testrunner/metric_generators.py
@@ -208,7 +208,7 @@ class RequestsMetricGenerator(MetricGenerator):
 
         metrics = Collection()
         metrics.add(Metric('server.app.response_time', context, MetricType.TIME, values=[
-            (float(single_run['headers']['x-backend-response-time']), None)
+            (float(single_run['time']), None)
             for single_run in data
         ]))
 

--- a/apps/testrunner/tasks/http_get.py
+++ b/apps/testrunner/tasks/http_get.py
@@ -14,12 +14,15 @@ logger = get_task_logger(__name__)
 
 
 class HttpGet(celery_app.Task):
+    def get_current_time(self):
+        return time.time()
+
     def run(self, url, retries=1, query_params=None):
         def run_test():
             logger.info('HTTP GET request: {} with params={}'.format(url, query_params))
-            start_time = time.time()
+            start_time = self.get_current_time()
             response = requests.get(url, params=query_params)
-            elapsed_time = time.time() - start_time
+            elapsed_time = self.get_current_time() - start_time
             if not response.ok:
                 logger.debug('HTTP status {}: {}'.format(response.status_code, response.content))
             response.raise_for_status()

--- a/apps/testrunner/tasks/http_get.py
+++ b/apps/testrunner/tasks/http_get.py
@@ -4,6 +4,7 @@ import re
 
 from celery.utils.log import get_task_logger
 import requests
+import time
 from common.utils import collect_results
 
 from testrunner import app as celery_app
@@ -16,13 +17,16 @@ class HttpGet(celery_app.Task):
     def run(self, url, retries=1, query_params=None):
         def run_test():
             logger.info('HTTP GET request: {} with params={}'.format(url, query_params))
+            start_time = time.time()
             response = requests.get(url, params=query_params)
+            elapsed_time = time.time() - start_time
             if not response.ok:
                 logger.debug('HTTP status {}: {}'.format(response.status_code, response.content))
             response.raise_for_status()
             return {
                 'content': response.text,
-                'headers': dict(response.headers)
+                'headers': dict(response.headers),
+                'time': elapsed_time
             }
 
         results = collect_results(run_test,retries)

--- a/tests/tests_tasks.py
+++ b/tests/tests_tasks.py
@@ -20,6 +20,13 @@ from tests.mocks.phantomas import PhantomasMock
 from tests.mocks.chrome import ChromeMock
 
 
+CURRENT_TIME_MOCK = 1401041000
+
+def time_time_mock(*args, **kwargs):
+    global CURRENT_TIME_MOCK
+    CURRENT_TIME_MOCK += 2
+    return CURRENT_TIME_MOCK
+
 @override_settings(CELERY_ALWAYS_EAGER=True)
 class TestResultTestCase(APITestCase):
     def setUp(self):
@@ -70,6 +77,7 @@ class TestResultTestCase(APITestCase):
     @mock.patch('testrunner.tasks.phantomas_get.phantomas.Phantomas', PhantomasMock)
     @mock.patch('testrunner.tasks.selenium_get.webdriver.Chrome', ChromeMock.create)
     @mock.patch('selenium.webdriver.support.wait.WebDriverWait', mock.MagicMock())
+    @mock.patch('testrunner.tasks.http_get.HttpGet.get_current_time',time_time_mock)
     @responses.activate
     @post_response
     def test_run_task(self, post_callback):
@@ -103,8 +111,8 @@ class TestResultTestCase(APITestCase):
 
         response_times = get_stats_from_requests('requests', 'server.app.response_time')
         self.assertEqual(response_times.count, 10)
-        self.assertEqual(response_times.min, 123.0)
-        self.assertEqual(response_times.max, 123.0)
+        self.assertEqual(response_times.min, 2.0)
+        self.assertEqual(response_times.max, 2.0)
 
         memcached_dupes = get_stats_from_requests('mw_profiler', 'server.app.memcached.dupe_count')
         memcached_misses = get_stats_from_requests('mw_profiler', 'server.app.memcached.miss_count')


### PR DESCRIPTION
Let's fall back to measure the time on client side when using requests. Hopefully this will fix some issues with backend time measurements.

/cc @harnash @jcellary 